### PR TITLE
fix: getSource wrong method

### DIFF
--- a/lib/elasticsearch.service.ts
+++ b/lib/elasticsearch.service.ts
@@ -40,7 +40,7 @@ export class ElasticsearchService {
   }
 
   getSource(params: GetSourceParams): Observable<any> {
-    return bindNodeCallback(this.bindClientContext(this.esClient.clearScroll))(
+    return bindNodeCallback(this.bindClientContext(this.esClient.getSource))(
       params
     );
   }


### PR DESCRIPTION
## PR Type
PR fixes getSource method

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
getSource method calls "clearScroll"

Issue Number: #1 


## What is the new behavior?
getSource passed throught correctly

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
